### PR TITLE
Revert "Support one-side chat and regenerate for named and anony tab." Due to Syntax Error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__
 *.egg-info
 dist
 .venv
-myenv
 
 # Log
 *.log

--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -37,8 +37,6 @@ from fastchat.utils import (
     moderation_filter,
 )
 
-from fastchat.serve.gradio_web_server import update_sandbox_system_message, add_text
-
 logger = build_logger("gradio_web_server_multi", "gradio_web_server_multi.log")
 
 num_sides = 2
@@ -70,8 +68,6 @@ def load_demo_side_by_side_named(models, url_params):
 
 
 def vote_last_response(states, vote_type, model_selectors, request: gr.Request):
-    if states[0] is None or states[1] is None:
-        return
     with open(get_conv_log_filename(), "a") as fout:
         data = {
             "tstamp": round(time.time(), 4),
@@ -123,44 +119,19 @@ def bothbad_vote_last_response(
     )
     return ("",) + (disable_btn,) * 4
 
-def regenerate(state, request: gr.Request):
-    ip = get_ip(request)
-    logger.info(f"regenerate. ip: {ip}")
-    if state is None:
-        return (None, None, "") + (no_change_btn,) * 8
-    if not state.regen_support:
-        state.skip_next = True
-        return (state, state.to_gradio_chatbot(), "", None) + (no_change_btn,) * 8
-    state.conv.update_last_message(None)
-    return (state, state.to_gradio_chatbot(), "") + (disable_btn,) * 8
 
-def regenerate_multi(state0, state1, request: gr.Request):
+def regenerate(state0, state1, request: gr.Request):
     logger.info(f"regenerate (named). ip: {get_ip(request)}")
     states = [state0, state1]
-
-    if state0 is None and state1 is not None:
-        if not state1.regen_support:
-            state1.skip_next = True
-            return states + [None, state1.to_gradio_chatbot()] + [""] + [no_change_btn] * 8  
-        state1.conv.update_last_message(None)
-        return states + [None, state1.to_gradio_chatbot()] + [""] + [disable_btn] * 8
-
-    if state1 is None and state0 is not None:
-        if not state0.regen_support:
-            state0.skip_next = True
-            return states + [state0.to_gradio_chatbot(), None] + [""] + [no_change_btn] * 8    
-        state0.conv.update_last_message(None)
-        return states + [state0.to_gradio_chatbot(), None] + [""] + [disable_btn] * 8 
-    
     if state0.regen_support and state1.regen_support:
         for i in range(num_sides):
             states[i].conv.update_last_message(None)
         return (
-            states + [x.to_gradio_chatbot() for x in states] + [""] + [disable_btn] * 8
+            states + [x.to_gradio_chatbot() for x in states] + [""] + [disable_btn] * 6
         )
     states[0].skip_next = True
     states[1].skip_next = True
-    return states + [x.to_gradio_chatbot() for x in states] + [""] + [no_change_btn] * 8
+    return states + [x.to_gradio_chatbot() for x in states] + [""] + [no_change_btn] * 6
 
 
 def clear_history(sandbox_state0, sandbox_state1, request: gr.Request):
@@ -174,9 +145,10 @@ def clear_history(sandbox_state0, sandbox_state1, request: gr.Request):
         + [None] * num_sides
         + [""]
         + [invisible_btn] * 4
-        + [disable_btn] * 1
-        + [invisible_btn] * 2
-,s(*components):
+        + [disable_btn] * 2
+    )
+
+def clear_sandbox_components(*components):
     updates = []
     for component in components:
         updates.append(gr.update(value="", visible=False))
@@ -212,14 +184,14 @@ def update_sandbox_system_messages_multi(state0, state1, sandbox_state0, sandbox
 
     return states + [x.to_gradio_chatbot() for x in states]
 
-def add_text_multi(
+def add_text(
     state0, state1,
     model_selector0, model_selector1,
     sandbox_state0, sandbox_state1,
     text, request: gr.Request
 ):
     ip = get_ip(request)
-    logger.info(f"add_text_multi (named). ip: {ip}. len: {len(text)}")
+    logger.info(f"add_text (named). ip: {ip}. len: {len(text)}")
     states = [state0, state1]
     model_selectors = [model_selector0, model_selector1]
     sandbox_states = [sandbox_state0, sandbox_state1]
@@ -240,7 +212,7 @@ def add_text_multi(
             + [
                 no_change_btn,
             ]
-            * 8
+            * 6
         )
 
     model_list = [states[i].model_name for i in range(num_sides)]
@@ -268,7 +240,7 @@ def add_text_multi(
             + [
                 no_change_btn,
             ]
-            * 8
+            * 6
         )
 
     text = text[:INPUT_CHAR_LEN_LIMIT]  # Hard cut-off
@@ -285,7 +257,7 @@ def add_text_multi(
         + [
             disable_btn,
         ]
-        * 8
+        * 6
     )
 
 
@@ -301,16 +273,15 @@ def bot_response_multi(
 ):
     logger.info(f"bot_response_multi (named). ip: {get_ip(request)}")
 
-    if state0 is not None and state1 is not None: 
-        if state0.skip_next or state1.skip_next:
-            # This generate call is skipped due to invalid inputs
-            yield (
-                state0,
-                state1,
-                state0.to_gradio_chatbot() ,
-                state1.to_gradio_chatbot() ,
-            ) + (no_change_btn,) * 8
-            return
+    if state0.skip_next:
+        # This generate call is skipped due to invalid inputs
+        yield (
+            state0,
+            state1,
+            state0.to_gradio_chatbot(),
+            state1.to_gradio_chatbot(),
+        ) + (no_change_btn,) * 6
+        return
 
     states = [state0, state1]
     gen = []
@@ -329,7 +300,7 @@ def bot_response_multi(
     model_tpy = []
     for i in range(num_sides):
         token_per_yield = 1
-        if states[i] is not None and states[i].model_name in [
+        if states[i].model_name in [
             "gemini-pro",
             "gemma-1.1-2b-it",
             "gemma-1.1-7b-it",
@@ -338,13 +309,13 @@ def bot_response_multi(
             "snowflake-arctic-instruct",
         ]:
             token_per_yield = 30
-        elif states[i] is not None and states[i].model_name in [
+        elif states[i].model_name in [
             "qwen-max-0428",
             "qwen-vl-max-0809",
             "qwen1.5-110b-chat",
         ]:
             token_per_yield = 7
-        elif states[i] is not None and  states[i].model_name in [
+        elif states[i].model_name in [
             "qwen2.5-72b-instruct",
             "qwen2-72b-instruct",
             "qwen-plus-0828",
@@ -368,15 +339,15 @@ def bot_response_multi(
                 stop = False
             except StopIteration:
                 pass
-        yield states + chatbots + [disable_btn] * 8
+        yield states + chatbots + [disable_btn] * 6
         if stop:
             break
 
 
 def flash_buttons():
     btn_updates = [
-        [disable_btn] * 4 + [enable_btn] * 4,
-        [enable_btn] * 8,
+        [disable_btn] * 4 + [enable_btn] * 2,
+        [enable_btn] * 6,
     ]
     for i in range(4):
         yield btn_updates[i % 2]
@@ -475,7 +446,7 @@ def build_side_by_side_ui_named(models):
                         sandbox_hidden_components.append(sandbox_row)
                         for chatbotIdx in range(num_sides):
                             with gr.Column(scale=1, visible=False) as column:
-                                sandbox_state = gr.State(create_chatbot_sandbox_state(btn_list_length=8))
+                                sandbox_state = gr.State(create_chatbot_sandbox_state())
                                 # Add containers for the sandbox output
                                 sandbox_title = gr.Markdown(value=f"### Model {chatbotIdx + 1} Sandbox", visible=False)
     
@@ -546,17 +517,11 @@ def build_side_by_side_ui_named(models):
             elem_id="input_box",
         )
         send_btn = gr.Button(value="Send", variant="primary", scale=0)
-        send_btn_left = gr.Button(value="Send to Left", variant="primary", scale=0)
-        send_btn_right = gr.Button(value="Send to Right", variant="primary", scale=0)
-        send_btns_one_side = [send_btn_left, send_btn_right]
 
     with gr.Row() as button_row:
         clear_btn = gr.Button(value="🗑️  Clear history", interactive=False)
         regenerate_btn = gr.Button(value="🔄  Regenerate", interactive=False)
-        left_regenerate_btn = gr.Button(value="🔄  Regenerate Left", interactive=False, visible=False)
-        right_regenerate_btn = gr.Button(value="🔄  Regenerate Right", interactive=False, visible=False)
         share_btn = gr.Button(value="📷  Share")
-        regenerate_one_side_btns = [left_regenerate_btn, right_regenerate_btn]
 
     with gr.Accordion("Parameters", open=False) as parameter_row:
         temperature = gr.Slider(
@@ -593,8 +558,6 @@ def build_side_by_side_ui_named(models):
         tie_btn,
         bothbad_btn,
         regenerate_btn,
-        left_regenerate_btn,
-        right_regenerate_btn,
         clear_btn,
     ]
     leftvote_btn.click(
@@ -618,7 +581,7 @@ def build_side_by_side_ui_named(models):
         [textbox, leftvote_btn, rightvote_btn, tie_btn, bothbad_btn],
     )
     regenerate_btn.click(
-        regenerate_multi, states, states + chatbots + [textbox] + btn_list
+        regenerate, states, states + chatbots + [textbox] + btn_list
     ).then(
         bot_response_multi,
         states + [temperature, top_p, max_output_tokens] + sandbox_states,
@@ -676,7 +639,7 @@ function (a, b, c, d) {
         )
 
     textbox.submit(
-        add_text_multi,
+        add_text,
         states + model_selectors + sandbox_states + [textbox],
         states + chatbots + sandbox_states + [textbox] + btn_list,
     ).then(
@@ -696,7 +659,7 @@ function (a, b, c, d) {
     )
 
     send_btn.click(
-        add_text_multi,
+        add_text,
         states + model_selectors + sandbox_states + [textbox],
         states + chatbots + sandbox_states + [textbox] + btn_list,
     ).then(
@@ -720,34 +683,6 @@ function (a, b, c, d) {
         state = states[chatbotIdx]
         sandbox_state = sandbox_states[chatbotIdx]
         sandbox_components = sandboxes_components[chatbotIdx]
-        model_selector = model_selectors[chatbotIdx]
-
-        send_btns_one_side[chatbotIdx].click(
-            add_text,
-            [state, model_selector, sandbox_state, textbox],
-            [state, chatbot, textbox] + btn_list,
-        ).then(
-            update_sandbox_system_message,
-            [state, sandbox_state, model_selector],
-            [state, chatbot]
-        ).then(
-            bot_response,
-            [state, temperature, top_p, max_output_tokens, sandbox_state],
-            [state, chatbot] + btn_list,
-        ).then(
-            flash_buttons, [], btn_list
-        ).then(
-            lambda sandbox_state: gr.update(interactive=sandbox_state['enabled_round'] == 0),
-            inputs=[sandbox_state],
-            outputs=[sandbox_env_choice]
-        )
-                
-        regenerate_one_side_btns[chatbotIdx].click(regenerate, state, [state, chatbot, textbox] + btn_list
-        ).then(
-            bot_response,
-            [state, temperature, top_p, max_output_tokens, sandbox_state],
-            [state, chatbot] + btn_list,
-       )
 
         # trigger sandbox run when click code message
         chatbot.select(

--- a/fastchat/serve/gradio_web_server.py
+++ b/fastchat/serve/gradio_web_server.py
@@ -370,7 +370,7 @@ def add_text(state, model_selector, sandbox_state, text, request: gr.Request):
 
     if len(text) <= 0:
         state.skip_next = True
-        return (state, state.to_gradio_chatbot(), "", None) + (no_change_btn,) * sandbox_state["btn_list_length"]
+        return (state, state.to_gradio_chatbot(), "", None) + (no_change_btn,) * 5
 
     all_conv_text = state.conv.get_prompt()
     all_conv_text = all_conv_text[-2000:] + "\nuser: " + text
@@ -386,12 +386,12 @@ def add_text(state, model_selector, sandbox_state, text, request: gr.Request):
         state.skip_next = True
         return (state, state.to_gradio_chatbot(), CONVERSATION_LIMIT_MSG, None) + (
             no_change_btn,
-        ) * sandbox_state["btn_list_length"]
+        ) * 5
 
     text = text[:INPUT_CHAR_LEN_LIMIT]  # Hard cut-off
     state.conv.append_message(state.conv.roles[0], text)
     state.conv.append_message(state.conv.roles[1], None)
-    return (state, state.to_gradio_chatbot(), "") + (disable_btn,) * sandbox_state["btn_list_length"]
+    return (state, state.to_gradio_chatbot(), "") + (disable_btn,) * 5
 
 
 def model_worker_stream_iter(
@@ -472,14 +472,10 @@ def bot_response(
     top_p = float(top_p)
     max_new_tokens = int(max_new_tokens)
 
-    if state is None:
-        yield (None, None) + (no_change_btn,) * sandbox_state["btn_list_length"]
-        return
-
     if state.skip_next:
         # This generate call is skipped due to invalid inputs
         state.skip_next = False
-        yield (state, state.to_gradio_chatbot()) + (no_change_btn,) * sandbox_state["btn_list_length"]
+        yield (state, state.to_gradio_chatbot()) + (no_change_btn,) * 5
         return
 
     if apply_rate_limit:
@@ -488,7 +484,7 @@ def bot_response(
             error_msg = RATE_LIMIT_MSG + "\n\n" + ret["reason"]
             logger.info(f"rate limit reached. ip: {ip}. error_msg: {ret['reason']}")
             state.conv.update_last_message(error_msg)
-            yield (state, state.to_gradio_chatbot()) + (no_change_btn,) * sandbox_state["btn_list_length"]
+            yield (state, state.to_gradio_chatbot()) + (no_change_btn,) * 5
             return
 
     conv: Conversation = state.conv
@@ -513,7 +509,11 @@ def bot_response(
             yield (
                 state,
                 state.to_gradio_chatbot(),
-                (disable_btn,) * sandbox_state["btn_list_length"],
+                disable_btn,
+                disable_btn,
+                disable_btn,
+                enable_btn,
+                enable_btn,
             )
             return
 
@@ -566,11 +566,8 @@ def bot_response(
     html_code = ' <span class="cursor"></span> '
 
     # conv.update_last_message("▌")
-    if conv is None:
-        yield (state, None) + (no_change_btn,) * sandbox_state["btn_list_length"]
-        return
     conv.update_last_message(html_code)
-    yield (state, state.to_gradio_chatbot()) + (disable_btn,) * (sandbox_state["btn_list_length"])
+    yield (state, state.to_gradio_chatbot()) + (disable_btn,) * 5
 
     try:
         data = {"text": ""}
@@ -579,12 +576,14 @@ def bot_response(
                 output = data["text"].strip()
                 conv.update_last_message(output + "▌")
                 # conv.update_last_message(output + html_code)
-                yield (state, state.to_gradio_chatbot()) + (disable_btn,) * sandbox_state["btn_list_length"]
+                yield (state, state.to_gradio_chatbot()) + (disable_btn,) * 5
             else:
                 output = data["text"] + f"\n\n(error_code: {data['error_code']})"
                 conv.update_last_message(output)
                 yield (state, state.to_gradio_chatbot()) + (
-                    (disable_btn,) * (sandbox_state["btn_list_length"]-2),
+                    disable_btn,
+                    disable_btn,
+                    disable_btn,
                     enable_btn,
                     enable_btn,
                 )
@@ -599,14 +598,16 @@ def bot_response(
                 if not last_message[1].endswith(RUN_CODE_BUTTON_HTML):
                     last_message[1] += "\n\n" + RUN_CODE_BUTTON_HTML
 
-        yield (state, state.to_gradio_chatbot()) + (enable_btn,) * sandbox_state["btn_list_length"]
+        yield (state, state.to_gradio_chatbot()) + (enable_btn,) * 5
     except requests.exceptions.RequestException as e:
         conv.update_last_message(
             f"{SERVER_ERROR_MSG}\n\n"
             f"(error_code: {ErrorCode.GRADIO_REQUEST_ERROR}, {e})"
         )
         yield (state, state.to_gradio_chatbot()) + (
-            (disable_btn,) * (sandbox_state["btn_list_length"]-2),
+            disable_btn,
+            disable_btn,
+            disable_btn,
             enable_btn,
             enable_btn,
         )
@@ -617,7 +618,9 @@ def bot_response(
             f"(error_code: {ErrorCode.GRADIO_STREAM_UNKNOWN_ERROR}, {e})"
         )
         yield (state, state.to_gradio_chatbot()) + (
-            (disable_btn,) * (sandbox_state["btn_list_length"]-2),
+            disable_btn,
+            disable_btn,
+            disable_btn,
             enable_btn,
             enable_btn,
         )
@@ -926,6 +929,7 @@ def build_single_model_ui(models, add_promotion_links=False):
         )
 
     # Sandbox state and components
+    sandbox_state = None
     sandboxes_components: list[SandboxGradioSandboxComponents] = []
     sandbox_hidden_components = []
 
@@ -945,7 +949,7 @@ def build_single_model_ui(models, add_promotion_links=False):
                 with sandbox_group:
                     sandbox_column = gr.Column(visible=False,scale=1)
                     with sandbox_column:
-                        sandbox_state = gr.State(create_chatbot_sandbox_state(btn_list_length=5))
+                        sandbox_state = gr.State(create_chatbot_sandbox_state())
                         # Add containers for the sandbox output
                         sandbox_title = gr.Markdown(value=f"### Model Sandbox", visible=False)
                         sandbox_output_tab = gr.Tab(label="Output", visible=False)
@@ -1126,10 +1130,6 @@ def build_single_model_ui(models, add_promotion_links=False):
         update_sandbox_system_message,
         [state, sandbox_state, model_selector],
         [state, chatbot]
-    ).then(
-        lambda sandbox_state: gr.update(sandbox_state['btn_list_length'] == len(btn_list)),
-        inputs=[sandbox_state],
-        outputs=[sandbox_state]
     ).then(
         bot_response,
         [state, temperature, top_p, max_output_tokens, sandbox_state],

--- a/fastchat/serve/sandbox/code_runner.py
+++ b/fastchat/serve/sandbox/code_runner.py
@@ -209,10 +209,9 @@ class ChatbotSandboxState(TypedDict):
     '''
     The code language to execute in the sandbox.
     '''
-    btn_list_length: int | None
 
 
-def create_chatbot_sandbox_state(btn_list_length: int) -> ChatbotSandboxState:
+def create_chatbot_sandbox_state() -> ChatbotSandboxState:
     '''
     Create a new chatbot sandbox state.
     '''
@@ -223,8 +222,7 @@ def create_chatbot_sandbox_state(btn_list_length: int) -> ChatbotSandboxState:
         "sandbox_instruction": None,
         "code_to_execute": "",
         "code_language": None,
-        "enabled_round": 0,
-        "btn_list_length": btn_list_length
+        "enabled_round": 0
     }
 
 


### PR DESCRIPTION
Logs:
```
Traceback (most recent call last): File "<frozen runpy>", line 198, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/content/FastChat-Software-Arena/fastchat/serve/gradio_web_server_multi.py", line 13, in <module> from fastchat.serve.gradio_block_arena_anony import ( File "/content/FastChat-Software-Arena/fastchat/serve/gradio_block_arena_anony.py", line 23, in <module> from fastchat.serve.gradio_block_arena_named import flash_buttons, update_sandbox_system_messages_multi File "/content/FastChat-Software-Arena/fastchat/serve/gradio_block_arena_named.py", line 171 return ( ^ SyntaxError: '(' was never closed
```