### PR TITLE
fix: add sandbox ui in side-by-side mode

### DIFF
--- a/fastchat/serve/gradio_block_arena_named.py
+++ b/fastchat/serve/gradio_block_arena_named.py
@@ -449,11 +449,10 @@ def build_side_by_side_ui_named(models):
                             with gr.Column(scale=1, visible=True) as column:
                                 sandbox_state = gr.State(create_chatbot_sandbox_state(btn_list_length=8))
                                 # Add containers for the sandbox output
-                                sandbox_title = gr.Markdown(value=f"### Model {chatbotIdx + 1} Sandbox", visible=False)
-
-                                with gr.Tab(label="Output", visible=False) as sandbox_output_tab:
-                                    sandbox_output = gr.Markdown(value="", visible=False)
-                                sandbox_title = gr.Markdown(value=f"### Model {chatbotIdx + 1} Sandbox", visible=True)
+                                sandbox_title = gr.Markdown(
+                                    value=f"### Model {chatbotIdx + 1} Sandbox",
+                                    visible=True,
+                                )
 
                                 with gr.Tab(label="Output", visible=True) as sandbox_output_tab:
                                     sandbox_output = gr.Markdown(value="", visible=True)
@@ -794,37 +793,37 @@ function (a, b, c, d) {
     leftvote_btn.click(
         leftvote_last_response,
         states + model_selectors,
-        [textbox, leftvote_btn, rightvote_btn, 
-         tie_btn, bothbad_btn, send_btn, send_btn_left, 
-         send_btn_right, regenerate_btn, left_regenerate_btn, 
+        [textbox, leftvote_btn, rightvote_btn,
+         tie_btn, bothbad_btn, send_btn, send_btn_left,
+         send_btn_right, regenerate_btn, left_regenerate_btn,
          right_regenerate_btn]
     )
 
     rightvote_btn.click(
         rightvote_last_response,
         states + model_selectors,
-        [textbox, leftvote_btn, rightvote_btn, 
-         tie_btn, bothbad_btn, send_btn, send_btn_left, 
-         send_btn_right, regenerate_btn, left_regenerate_btn, 
-         right_regenerate_btn]    
+        [textbox, leftvote_btn, rightvote_btn,
+         tie_btn, bothbad_btn, send_btn, send_btn_left,
+         send_btn_right, regenerate_btn, left_regenerate_btn,
+         right_regenerate_btn]
     )
 
     tie_btn.click(
         tievote_last_response,
         states + model_selectors,
-        [textbox, leftvote_btn, rightvote_btn, 
-         tie_btn, bothbad_btn, send_btn, send_btn_left, 
-         send_btn_right, regenerate_btn, left_regenerate_btn, 
-         right_regenerate_btn]    
+        [textbox, leftvote_btn, rightvote_btn,
+         tie_btn, bothbad_btn, send_btn, send_btn_left,
+         send_btn_right, regenerate_btn, left_regenerate_btn,
+         right_regenerate_btn]
     )
 
     bothbad_btn.click(
         bothbad_vote_last_response,
         states + model_selectors,
-        [textbox, leftvote_btn, rightvote_btn, 
-         tie_btn, bothbad_btn, send_btn, send_btn_left, 
-         send_btn_right, regenerate_btn, left_regenerate_btn, 
-         right_regenerate_btn]    
+        [textbox, leftvote_btn, rightvote_btn,
+         tie_btn, bothbad_btn, send_btn, send_btn_left,
+         send_btn_right, regenerate_btn, left_regenerate_btn,
+         right_regenerate_btn]
     )
 
     return states + model_selectors


### PR DESCRIPTION
This pull request includes a change to the `build_side_by_side_ui_named` function in the `fastchat/serve/gradio_block_arena_named.py` file. The change simplifies the code by removing redundant lines and ensuring the sandbox title and output tab are always visible.

Code simplification:

* [`fastchat/serve/gradio_block_arena_named.py`](diffhunk://#diff-ea555a0a94c6de1212590c9bc687a5614f977458bc8dfed5765861ab2172656bL452-R455): Removed redundant code and ensured the sandbox title and output tab are always visible in the `build_side_by_side_ui_named` function.<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
