### PR TITLE
Fix docker init command to use correct register file

### DIFF
--- a/swe_arena_serve.Dockerfile
+++ b/swe_arena_serve.Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 7860
 CMD [ "python", "-m", \
         "fastchat.serve.gradio_web_server_multi", \
         "--controller-url", "", \
-        "--register", "api_endpoints.json" ]
+        "--register", "api_endpoints_serve.json" ]


### PR DESCRIPTION
Update the Docker command to reference the correct `api_endpoints_serve.json` file instead of `api_endpoints.json`.